### PR TITLE
Add basic api layer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ managed = true
 dev-dependencies = [
     "pytest>=8.3.3",
     "ruff>=0.8.1",
+    "httpx>=0.28.0",
 ]
 
 [tool.hatch.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 dependencies = [
     "fastapi>=0.115.5",
+    "uvicorn[standard]>=0.32.1",
 ]
 readme = "README.md"
 requires-python = ">= 3.8"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -14,8 +14,15 @@ annotated-types==0.7.0
     # via pydantic
 anyio==4.6.2.post1
     # via starlette
+    # via watchfiles
+click==8.1.7
+    # via uvicorn
 fastapi==0.115.5
     # via eternalog
+h11==0.14.0
+    # via uvicorn
+httptools==0.6.4
+    # via uvicorn
 idna==3.10
     # via anyio
 iniconfig==2.0.0
@@ -29,6 +36,10 @@ pydantic==2.10.2
 pydantic-core==2.27.1
     # via pydantic
 pytest==8.3.3
+python-dotenv==1.0.1
+    # via uvicorn
+pyyaml==6.0.2
+    # via uvicorn
 ruff==0.8.1
 sniffio==1.3.1
     # via anyio
@@ -38,3 +49,11 @@ typing-extensions==4.12.2
     # via fastapi
     # via pydantic
     # via pydantic-core
+uvicorn==0.32.1
+    # via eternalog
+uvloop==0.21.0
+    # via uvicorn
+watchfiles==1.0.0
+    # via uvicorn
+websockets==14.1
+    # via uvicorn

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -13,18 +13,27 @@
 annotated-types==0.7.0
     # via pydantic
 anyio==4.6.2.post1
+    # via httpx
     # via starlette
     # via watchfiles
+certifi==2024.8.30
+    # via httpcore
+    # via httpx
 click==8.1.7
     # via uvicorn
 fastapi==0.115.5
     # via eternalog
 h11==0.14.0
+    # via httpcore
     # via uvicorn
+httpcore==1.0.7
+    # via httpx
 httptools==0.6.4
     # via uvicorn
+httpx==0.28.0
 idna==3.10
     # via anyio
+    # via httpx
 iniconfig==2.0.0
     # via pytest
 packaging==24.2

--- a/requirements.lock
+++ b/requirements.lock
@@ -14,14 +14,25 @@ annotated-types==0.7.0
     # via pydantic
 anyio==4.6.2.post1
     # via starlette
+    # via watchfiles
+click==8.1.7
+    # via uvicorn
 fastapi==0.115.5
     # via eternalog
+h11==0.14.0
+    # via uvicorn
+httptools==0.6.4
+    # via uvicorn
 idna==3.10
     # via anyio
 pydantic==2.10.2
     # via fastapi
 pydantic-core==2.27.1
     # via pydantic
+python-dotenv==1.0.1
+    # via uvicorn
+pyyaml==6.0.2
+    # via uvicorn
 sniffio==1.3.1
     # via anyio
 starlette==0.41.3
@@ -30,3 +41,11 @@ typing-extensions==4.12.2
     # via fastapi
     # via pydantic
     # via pydantic-core
+uvicorn==0.32.1
+    # via eternalog
+uvloop==0.21.0
+    # via uvicorn
+watchfiles==1.0.0
+    # via uvicorn
+websockets==14.1
+    # via uvicorn

--- a/src/eternalog/api/__init__.py
+++ b/src/eternalog/api/__init__.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+
+from eternalog.api.v1 import v1_router
+
+
+def create_api() -> FastAPI:
+    api = FastAPI(
+        title="Eternalog",
+        description="An immutable log storage/versioning service.",
+        version="0.1.0",
+    )
+    api.include_router(v1_router)
+    return api

--- a/src/eternalog/api/v1/__init__.py
+++ b/src/eternalog/api/v1/__init__.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+from eternalog.api.v1 import test_router
+
+v1_router = APIRouter(
+    prefix="/api/v1",
+    tags=["v1"],
+)
+v1_router.include_router(test_router.router, tags=test_router.ROUTER_TAGS)

--- a/src/eternalog/api/v1/test_router.py
+++ b/src/eternalog/api/v1/test_router.py
@@ -1,0 +1,20 @@
+import pydantic
+from fastapi import APIRouter
+
+ROUTER_TAGS: list[str] = ["Test", "v1"]
+ROUTER_PATH = "/test"
+
+router = APIRouter(
+    prefix=ROUTER_PATH,
+    tags=ROUTER_TAGS,
+    responses={404: {"description": "Not found"}},
+)
+
+
+class TestResponse(pydantic.BaseModel):
+    message: str
+
+
+@router.get("/echo/{message}")
+def echo(message: str) -> TestResponse:
+    return TestResponse(message=message)

--- a/src/eternalog/entrypoints.py
+++ b/src/eternalog/entrypoints.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+from eternalog.api import create_api
+
+
+def get_application() -> FastAPI:
+    return create_api()

--- a/src/eternalog/main.py
+++ b/src/eternalog/main.py
@@ -1,0 +1,3 @@
+from eternalog.entrypoints import get_application
+
+app = get_application()

--- a/src/tests/functional/test_test_router.py
+++ b/src/tests/functional/test_test_router.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+from eternalog.main import app
+
+
+class TestTestRouter:
+    def test_echo(self):
+        with TestClient(app) as client:
+            test_message = "hello"
+            response = client.get(f"api/v1/test/echo/{test_message}")
+            assert response.status_code == 200
+            assert response.json() == {"message": "hello"}


### PR DESCRIPTION
This PR adds:

* A basic echo endpoint
* A simple harness for building API's from endpoint routers
* the `entrypoints.py` file for building the API
* the `main.py` file for instantiating an instance of the built API. 